### PR TITLE
fix: bumped golang versions to 1.17.8 to support arm64 resolves #53

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17.8
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: '1.15'
+        go-version: '1.17.8'
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chronark/terraform-provider-fauna
 
-go 1.15
+go 1.17
 
 require (
 	github.com/fauna/faunadb-go/v3 v3.0.0


### PR DESCRIPTION
Issue: 

Terraform init was failing because currently used golang version does't support arm64 M1 Mac

Solution:

Version bumped Golang version to 1.17.8

